### PR TITLE
Expose Event data constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.5
+
+- Expose Event data constructor.	
+
 ### 0.1.4
 
 - Support for GHC 8.0.1.

--- a/event.cabal
+++ b/event.cabal
@@ -1,5 +1,6 @@
+
 name:                event
-version:             0.1.4
+version:             0.1.5
 synopsis:            Monoidal, monadic and first-class events
 description:         This package can be used to represent events as
                      first-class objects instead of deepening callbacks and

--- a/src/Control/Concurrent/Event.hs
+++ b/src/Control/Concurrent/Event.hs
@@ -49,7 +49,7 @@
 
 module Control.Concurrent.Event (
     -- * Events
-    Event
+    Event(..)
   , Detach(..)
   , on
   , newEvent


### PR DESCRIPTION
I think it's very useful to expose the internals of Event, so to allow users to write their own event combinators without having to hack the library and send PRs every time.